### PR TITLE
fix(build): allow empty SCSS files

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -56,7 +56,7 @@ gulp.task('build:esm:watch', ['build:esm'], () => {
  */
 function compileSass(path, ext, file, callback) {
   let compiledCss = sass.renderSync({
-    data: file,
+    data: file || '// nothing',
     outputStyle: 'compressed',
   });
   callback(null, compiledCss.css);


### PR DESCRIPTION
Fix for the next case: 
`npm run build:watch` fails with `throw new Error('No input specified: provide a file name or a source string to process');` if component's SCSS file is empty (usual case when component created by `ng g component` scaffolding).